### PR TITLE
pass Store constructor to change callback to support generic change hand...

### DIFF
--- a/utils/BaseStore.js
+++ b/utils/BaseStore.js
@@ -46,7 +46,7 @@ BaseStore.prototype.removeChangeListener = function(callback) {
  * @method emitChange
  */
 BaseStore.prototype.emitChange = function() {
-  this.emit(CHANGE_EVENT);
+  this.emit(CHANGE_EVENT, this.constructor);
 };
 
 module.exports = BaseStore;


### PR DESCRIPTION
...lers

It looks like the store name is used in the actual Dispatcher, maybe the name would be better here, too.

Does a change like this (passing a store identifier to the change handler) make sense to you guys?
