### PR TITLE
removed unnecessary spec.statics check

### DIFF
--- a/utils/createStore.js
+++ b/utils/createStore.js
@@ -57,11 +57,10 @@ module.exports = function createStore(spec) {
 
     util.inherits(Store, BaseStore);
 
-    if (spec.statics) {
-        Object.keys(spec.statics).forEach(function (prop) {
-            Store[prop] = spec.statics[prop];
-        });
-    }
+    Object.keys(spec.statics).forEach(function (prop) {
+        Store[prop] = spec.statics[prop];
+    });
+
     Store.storeName = spec.storeName || Store.storeName;
     Store.handlers = spec.handlers || Store.handlers;
     Store.mixins = spec.mixins || Store.mixins;


### PR DESCRIPTION
We're already making sure `spec.statics` exists above.

``` js
...
module.exports = function createStore(spec) {
    spec.statics = spec.statics || {};
...
```
