### PR TITLE
add getContext() convenience method to BaseStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ These utilities make creating stores less verbose and provide some `change` rela
 
 ### BaseStore
 
-`require('dispatchr/utils/BaseStore')` provides a base store class for extending. Provides `emitChange`, `addChangeListener`, and `removeChangeListener` functions. Example:
+`require('dispatchr/utils/BaseStore')` provides a base store class for extending. Provides `getContext`, `emitChange`, `addChangeListener`, and `removeChangeListener` functions. Example:
 
 ```js
 var util = require('util');
@@ -191,7 +191,7 @@ MyStore.storeName = 'MyStore';
 MyStore.handlers = {
     'NAVIGATE': function (payload) { ... this.emitChange() ... }
 };
-MyStore.prototype.getFoo = function () { ... }
+MyStore.prototype.getFoo = function () { var context = this.getContext(), ... }
 module.exports = MyStore;
 ```
 

--- a/tests/unit/utils/BaseStore.js
+++ b/tests/unit/utils/BaseStore.js
@@ -1,0 +1,34 @@
+/*globals describe,it */
+"use strict";
+
+var expect = require('chai').expect;
+var BaseStore = require('../../../utils/BaseStore');
+
+var contextMock = {
+    dimensions: {}
+};
+var dispatcherMock = {
+        getContext: function () {
+            return contextMock;
+        }
+    };
+
+describe('BaseStore', function () {
+    it('Constructor', function () {
+        var store = new BaseStore(dispatcherMock);
+        expect(store.dispatcher).to.equal(dispatcherMock);
+        expect(store.getContext()).to.equal(dispatcherMock.getContext());
+    });
+
+    it('change event management', function (done) {
+        var store = new BaseStore(dispatcherMock);
+        var payloadMock = {
+            foo: 'bar'
+        };
+        store.addChangeListener(function (payload) {
+            expect(payload.foo).to.equal('bar');
+            done();
+        });
+        store.emitChange(payloadMock);
+    });
+});

--- a/utils/BaseStore.js
+++ b/utils/BaseStore.js
@@ -4,9 +4,9 @@
  */
 'use strict';
 
-var util = require('util'),
-    EventEmitter = require('events').EventEmitter,
-    CHANGE_EVENT = 'change';
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var CHANGE_EVENT = 'change';
 
 /**
  * @class BaseStore
@@ -22,6 +22,15 @@ function BaseStore(dispatcher) {
 }
 
 util.inherits(BaseStore, EventEmitter);
+
+/**
+ * Convenience method for getting the store context object.
+ * @method getContext
+ * @return {Object} Returns the store context object.
+ */
+BaseStore.prototype.getContext = function getContext() {
+  return this.dispatcher.getContext();
+};
 
 /**
  * Add a listener for the change event


### PR DESCRIPTION
@mridgway @redonkulus @Vijar @jedireza 

Currently, store developers have to use `this.dispatcher.getContext()` to get to the store context.  This PR adds a convenience method `this.getContext()` to wrap around that functionality.
