### PR TITLE
Throw DispatchError on nested call to Dispatcher::dispatch

### DIFF
--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -5,10 +5,13 @@
 'use strict';
 
 var Action = require('./Action'),
+    DispatchError = require('./Error/DispatchError'),
     DEFAULT = 'default';
 
 module.exports = function () {
     var debug = require('debug')('Dispatchr:dispatcher');
+    var error = require('debug')('Dispatchr:dispatcher');
+    error.log = console.error.bind(console);
 
     /**
      * @class Dispatcher
@@ -148,7 +151,7 @@ module.exports = function () {
      */
     Dispatcher.prototype.dispatch = function dispatch(actionName, payload) {
         if (this.currentAction) {
-            throw new Error('Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.');
+            throw new DispatchError('Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.');
         }
         var actionHandlers = Dispatcher.handlers[actionName] || [],
             defaultHandlers = Dispatcher.handlers[DEFAULT] || [];
@@ -176,8 +179,16 @@ module.exports = function () {
                 handlerFns[store.name] = storeInstance[store.handler].bind(storeInstance);
             }
         });
-        this.currentAction.execute(handlerFns);
-        debug('finished ' + this.currentAction.name);
+        try {
+            this.currentAction.execute(handlerFns);
+            debug('finished ' + this.currentAction.name);
+        } catch(err) {
+            if (err instanceof DispatchError) {
+                throw err;
+            }
+
+            error('error executing action ' + this.currentAction.name, err);
+        }
         this.currentAction = null;
     };
 

--- a/lib/Error/DispatchError.js
+++ b/lib/Error/DispatchError.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+function DispatchError(message) {
+    this.message = message || '';
+}
+
+DispatchError.prototype = new Error();
+DispatchError.prototype.name = 'DispatchError';
+DispatchError.prototype.constructor = DispatchError;
+
+module.exports = DispatchError;

--- a/tests/mock/Store.js
+++ b/tests/mock/Store.js
@@ -37,6 +37,10 @@ Store.prototype.dispatch = function (payload) {
     this.emitChange();
 };
 
+Store.prototype.error = function (payload) {
+    throw new Error(payload.message);
+};
+
 Store.prototype.getState = function () {
     return this.state;
 };

--- a/tests/unit/lib/DispatchError.js
+++ b/tests/unit/lib/DispatchError.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/*globals describe,it,before,beforeEach */
+'use strict';
+
+var expect = require('chai').expect;
+var DispatchError = require('../../../lib/Error/DispatchError');
+
+describe('DispatchError', function () {
+    it('exists', function () {
+        var err = new DispatchError();
+        expect(err).to.be.an.instanceof(DispatchError);
+        expect(err.name).to.equal('DispatchError');
+    });
+
+    it('has a message', function () {
+        var err = new DispatchError('foo');
+        expect(err.message).to.equal('foo');
+    });
+
+    it('is an Error', function () {
+        var err = new DispatchError();
+        expect(err).to.be.an.instanceof(Error);
+    });
+});

--- a/tests/unit/lib/Dispatcher.js
+++ b/tests/unit/lib/Dispatcher.js
@@ -10,6 +10,7 @@ var Dispatcher = require('../../../index')();
 var mockStore = require('../../mock/Store');
 var delayedStore = require('../../mock/DelayedStore');
 var noDehydrateStore = require('../../mock/NoDehydrate');
+var DispatchError = require('../../../lib/Error/DispatchError');
 
 describe('Dispatchr', function () {
 
@@ -149,15 +150,15 @@ describe('Dispatchr', function () {
             expect(dispatcher.getStore(delayedStore).actionHandled).to.equal(null);
         });
 
-        it('should not swallow errors raised by store handler', function () {
+        it('should swallow Errors raised by store handler', function () {
             var context = {test: 'test'},
                 dispatcher = new Dispatcher(context);
             expect(function () {
-                dispatcher.dispatch('ERROR', {});
-            }).to.throw();
+                dispatcher.dispatch('ERROR', {message: 'foo'});
+            }).to.not.throw('foo');
         });
 
-        it('should throw if a dispatch called within dispatch', function () {
+        it('should throw DispatchError if a dispatch called within dispatch', function () {
             var context = {test: 'test'},
                 dispatcher = new Dispatcher(context);
 
@@ -165,7 +166,7 @@ describe('Dispatchr', function () {
                 dispatcher.dispatch('DISPATCH', {
                     dispatcher: dispatcher
                 });
-            }).to.throw();
+            }).to.throw(DispatchError);
         });
     });
 


### PR DESCRIPTION
Suggested implementation for handling errors thrown in store handlers (see #46).

Uses custom error types to differentiate between a generic/user-land error thrown during a store handler and Dispatchr throwing when calls to `Dispatcher::dispatch` are nested.

M