### PR TITLE
Pure prototypal inheritance

### DIFF
--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -5,30 +5,38 @@
 'use strict';
 
 var Action = require('./Action'),
-    DEFAULT = 'default';
+    BaseStore = require('../utils/BaseStore'),
+    DEFAULT = 'default',
+    debug = require('debug')('Dispatchr:dispatcher');
 
-module.exports = function () {
-    var debug = require('debug')('Dispatchr:dispatcher');
+/**
+ * @class Dispatcher
+ * @param {Object} context The context to be used for store instances
+ * @constructor
+ */
+module.exports = {
+    stores: {},
+    handlers: {
+        'default': []
+    },
 
     /**
-     * @class Dispatcher
+     * Creates a new dispatchr instance
      * @param {Object} context The context to be used for store instances
      * @constructor
      */
-    function Dispatcher (context) {
-        this.storeInstances = {};
-        this.currentAction = null;
-        this.dispatcherInterface = {
+    create: function (context) {
+        var obj = Object.create(this);
+        obj.storeInstances = {};
+        obj.currentAction = null;
+        obj.dispatcherInterface = {
             getContext: function getContext() { return context; },
-            getStore: this.getStore.bind(this),
-            waitFor: this.waitFor.bind(this)
+            getStore: obj.getStore.bind(obj),
+            waitFor: obj.waitFor.bind(obj)
         };
-    }
 
-    Dispatcher.stores = {};
-    Dispatcher.handlers = {
-        'default': []
-    };
+        return obj;
+    },
 
     /**
      * Registers a store so that it can handle actions.
@@ -39,29 +47,35 @@ module.exports = function () {
      * @throws {Error} if store is invalid
      * @throws {Error} if store is already registered
      */
-    Dispatcher.registerStore = function registerStore(store) {
-        if ('function' !== typeof store) {
+    registerStore: function registerStore(store) {
+        if (!BaseStore.isPrototypeOf(store)) {
             throw new Error('registerStore requires a constructor as first parameter');
         }
-        var storeName = Dispatcher.getStoreName(store);
+
+        var storeName = this.getStoreName(store);
         if (!storeName) {
             throw new Error('Store is required to have a `storeName` property.');
         }
-        if (Dispatcher.stores[storeName]) {
-            if (Dispatcher.stores[storeName] === store) {
+
+        if (!this.hasOwnProperty('stores')) {
+            this.stores = {};
+        }
+
+        if (this.stores[storeName]) {
+            if (this.stores[storeName] === store) {
                 // Store is already registered, nothing to do
                 return;
             }
             throw new Error('Store with name `' + storeName + '` has already been registered.');
         }
-        Dispatcher.stores[storeName] = store;
+        this.stores[storeName] = store;
         if (store.handlers) {
             Object.keys(store.handlers).forEach(function storeHandlersEach(action) {
                 var handler = store.handlers[action];
-                Dispatcher._registerHandler(action, storeName, handler);
-            });
+                this._registerHandler(action, storeName, handler);
+            }, this);
         }
-    };
+    },
 
     /**
      * Method to discover if a storeName has been registered
@@ -70,9 +84,9 @@ module.exports = function () {
      * @param {Object|String} store The store to check
      * @returns {boolean}
      */
-    Dispatcher.isRegistered = function isRegistered(store) {
-        var storeName = Dispatcher.getStoreName(store),
-            storeInstance = Dispatcher.stores[storeName];
+    isRegistered: function isRegistered(store) {
+        var storeName = this.getStoreName(store),
+            storeInstance = this.stores[storeName];
 
         if (!storeInstance) {
             return false;
@@ -84,7 +98,7 @@ module.exports = function () {
             }
         }
         return true;
-    };
+    },
 
     /**
      * Gets a name from a store
@@ -94,12 +108,12 @@ module.exports = function () {
      *      the name
      * @returns {String}
      */
-    Dispatcher.getStoreName = function getStoreName(store) {
+    getStoreName: function getStoreName(store) {
         if ('string' === typeof store) {
             return store;
         }
         return store.storeName;
-    };
+    },
 
     /**
      * Adds a handler function to be called for the given action
@@ -111,14 +125,18 @@ module.exports = function () {
      * @param {String|Function} handler The function or name of the method that handles the action
      * @returns {number}
      */
-    Dispatcher._registerHandler = function registerHandler(action, name, handler) {
-        Dispatcher.handlers[action] = Dispatcher.handlers[action] || [];
-        Dispatcher.handlers[action].push({
-            name: Dispatcher.getStoreName(name),
+    _registerHandler: function registerHandler(action, name, handler) {
+        if (!this.hasOwnProperty('handlers')) {
+            this.handlers = {};
+        }
+
+        this.handlers[action] = this.handlers[action] || [];
+        this.handlers[action].push({
+            name: this.getStoreName(name),
             handler: handler
         });
-        return Dispatcher.handlers.length - 1;
-    };
+        return this.handlers.length - 1;
+    },
 
     /**
      * Returns a single store instance and creates one if it doesn't already exist
@@ -127,17 +145,17 @@ module.exports = function () {
      * @returns {Object} The store instance
      * @throws {Error} if store is not registered
      */
-    Dispatcher.prototype.getStore = function getStore(name) {
-        var storeName = Dispatcher.getStoreName(name);
+    getStore: function getStore(name) {
+        var storeName = this.getStoreName(name);
         if (!this.storeInstances[storeName]) {
-            var Store = Dispatcher.stores[storeName];
+            var Store = this.stores[storeName];
             if (!Store) {
                 throw new Error('Store ' + storeName + ' was not registered.');
             }
-            this.storeInstances[storeName] = new (Dispatcher.stores[storeName])(this.dispatcherInterface);
+            this.storeInstances[storeName] = this.stores[storeName].create(this.dispatcherInterface);
         }
         return this.storeInstances[storeName];
-    };
+    },
 
     /**
      * Dispatches a new action or queues it up if one is already in progress
@@ -146,20 +164,19 @@ module.exports = function () {
      * @param {Object} payload Parameters to describe the action
      * @throws {Error} if store has handler registered that does not exist
      */
-    Dispatcher.prototype.dispatch = function dispatch(actionName, payload) {
+    dispatch: function dispatch(actionName, payload) {
         if (this.currentAction) {
             throw new Error('Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.');
         }
-        var actionHandlers = Dispatcher.handlers[actionName] || [],
-            defaultHandlers = Dispatcher.handlers[DEFAULT] || [];
+        var actionHandlers = this.handlers[actionName] || [],
+            defaultHandlers = this.handlers[DEFAULT] || [];
         if (!actionHandlers.length && !defaultHandlers.length) {
             debug(actionName + ' does not have any registered handlers');
             return;
         }
         debug('dispatching ' + actionName, payload);
         this.currentAction = new Action(actionName, payload);
-        var self = this,
-            allHandlers = actionHandlers.concat(defaultHandlers),
+        var allHandlers = actionHandlers.concat(defaultHandlers),
             handlerFns = {};
 
         try {
@@ -168,7 +185,7 @@ module.exports = function () {
                     // Don't call the default if the store has an explicit action handler
                     return;
                 }
-                var storeInstance = self.getStore(store.name);
+                var storeInstance = this.getStore(store.name);
                 if ('function' === typeof store.handler) {
                     handlerFns[store.name] = store.handler.bind(storeInstance);
                 } else {
@@ -177,7 +194,7 @@ module.exports = function () {
                     }
                     handlerFns[store.name] = storeInstance[store.handler].bind(storeInstance);
                 }
-            });
+            }, this);
             this.currentAction.execute(handlerFns);
         } catch (e) {
             throw e;
@@ -185,7 +202,7 @@ module.exports = function () {
             debug('finished ' + actionName);
             this.currentAction = null;
         }
-    };
+    },
 
     /**
      * Returns a raw data object representation of the current state of the
@@ -194,20 +211,19 @@ module.exports = function () {
      * @method dehydrate
      * @returns {Object} dehydrated dispatcher data
      */
-    Dispatcher.prototype.dehydrate = function dehydrate() {
-        var self = this,
-            stores = {};
-        Object.keys(self.storeInstances).forEach(function storeInstancesEach(storeName) {
-            var store = self.storeInstances[storeName];
+    dehydrate: function dehydrate() {
+        var stores = {};
+        Object.keys(this.storeInstances).forEach(function storeInstancesEach(storeName) {
+            var store = this.storeInstances[storeName];
             if (!store.dehydrate || (store.shouldDehydrate && !store.shouldDehydrate())) {
                 return;
             }
             stores[storeName] = store.dehydrate();
-        });
+        }, this);
         return {
             stores: stores
         };
-    };
+    },
 
     /**
      * Takes a raw data object and rehydrates the dispatcher and store instances
@@ -215,18 +231,17 @@ module.exports = function () {
      * @param {Object} dispatcherState raw state typically retrieved from `dehydrate`
      *      method
      */
-    Dispatcher.prototype.rehydrate = function rehydrate(dispatcherState) {
-        var self = this;
+    rehydrate: function rehydrate(dispatcherState) {
         if (dispatcherState.stores) {
             Object.keys(dispatcherState.stores).forEach(function storeStateEach(storeName) {
                 var state = dispatcherState.stores[storeName],
-                    store = self.getStore(storeName);
+                    store = this.getStore(storeName);
                 if (store.rehydrate) {
                     store.rehydrate(state);
                 }
-            });
+            }, this);
         }
-    };
+    },
 
     /**
      * Waits until all stores have finished handling an action and then calls
@@ -236,12 +251,10 @@ module.exports = function () {
      * @param {Function} callback Called after all stores have completed handling their actions
      * @throws {Error} if there is no action dispatching
      */
-    Dispatcher.prototype.waitFor = function waitFor(stores, callback) {
+    waitFor: function waitFor(stores, callback) {
         if (!this.currentAction) {
             throw new Error('waitFor called even though there is no action dispatching');
         }
         this.currentAction.waitFor(stores, callback);
-    };
-
-    return Dispatcher;
+    }
 };

--- a/tests/mock/Store.js
+++ b/tests/mock/Store.js
@@ -6,20 +6,17 @@ var util = require('util'),
     BaseStore = require('../../utils/BaseStore'),
     DelayedStore = require('./DelayedStore');
 
-function Store(dispatcher) {
-    BaseStore.call(this, dispatcher);
-}
+var Store = BaseStore.create();
 
 Store.storeName = 'Store';
-util.inherits(Store, BaseStore);
 
-Store.prototype.initialize = function () {
+Store.initialize = function () {
     this.state = {
         called: false
     };
 };
 
-Store.prototype.delay = function (payload) {
+Store.delay = function (payload) {
     var self = this;
     self.state.called = true;
     self.dispatcher.waitFor(DelayedStore, function () {
@@ -32,20 +29,20 @@ Store.prototype.delay = function (payload) {
     });
 };
 
-Store.prototype.dispatch = function (payload) {
+Store.dispatch = function (payload) {
     payload.dispatcher.dispatch('DISPATCH_IN_DISPATCH');
     this.emitChange();
 };
 
-Store.prototype.getState = function () {
+Store.getState = function () {
     return this.state;
 };
 
-Store.prototype.dehydrate = function () {
+Store.dehydrate = function () {
     return this.state;
 };
 
-Store.prototype.rehydrate = function (state) {
+Store.rehydrate = function (state) {
     this.state = state;
 };
 

--- a/tests/unit/lib/Dispatcher.js
+++ b/tests/unit/lib/Dispatcher.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var expect = require('chai').expect;
-var Dispatcher = require('../../../index')();
+var Dispatcher = require('../../../index').create();
 var mockStore = require('../../mock/Store');
 var delayedStore = require('../../mock/DelayedStore');
 var noDehydrateStore = require('../../mock/NoDehydrate');
@@ -20,7 +20,7 @@ describe('Dispatchr', function () {
     });
 
     it('should not bleed between requires', function () {
-        var Dispatcher2 = require('../../../lib/Dispatcher')();
+        var Dispatcher2 = require('../../../index').create();
         expect(Dispatcher2.isRegistered(mockStore)).to.equal(false);
         Dispatcher2.registerStore(delayedStore);
         expect(Dispatcher2.isRegistered(delayedStore)).to.equal(true);
@@ -28,7 +28,7 @@ describe('Dispatchr', function () {
 
     it('should have handlers registered', function () {
         expect(Dispatcher.stores).to.be.an('object');
-        expect(Dispatcher.stores.Store).to.be.a('function');
+        expect(Dispatcher.stores.Store).to.be.a('object');
         expect(Dispatcher.handlers).to.be.an('object');
         expect(Dispatcher.handlers.NAVIGATE).to.be.an('array');
         expect(Dispatcher.handlers.NAVIGATE.length).to.equal(2);
@@ -46,7 +46,7 @@ describe('Dispatchr', function () {
         it('should not throw if store is registered twice (should silently do nothing)', function () {
             Dispatcher.registerStore(mockStore);
             expect(Dispatcher.stores).to.be.an('object');
-            expect(Dispatcher.stores.Store).to.be.a('function');
+            expect(Dispatcher.stores.Store).to.be.a('object');
         });
 
         it('should throw if store is not a constructor', function () {
@@ -74,7 +74,7 @@ describe('Dispatchr', function () {
 
     describe('#getStore', function () {
         it('should give me the same store instance', function () {
-            var dispatcher = new Dispatcher({}),
+            var dispatcher = Dispatcher.create({}),
                 mockStoreInstance = dispatcher.getStore('Store');
 
             expect(mockStoreInstance).to.be.an('object');
@@ -82,7 +82,7 @@ describe('Dispatchr', function () {
             expect(dispatcher.getStore('Store')).to.equal(mockStoreInstance);
         });
         it('should allow passing constructor instead of class name', function () {
-            var dispatcher = new Dispatcher({}),
+            var dispatcher = Dispatcher.create({}),
                 mockStoreInstance = dispatcher.getStore(mockStore);
 
             expect(mockStoreInstance).to.be.an('object');
@@ -90,7 +90,7 @@ describe('Dispatchr', function () {
             expect(dispatcher.getStore('Store')).to.equal(mockStoreInstance);
         });
         it('should throw if name is invalid', function () {
-            var dispatcher = new Dispatcher({});
+            var dispatcher = Dispatcher.create({});
 
             expect(function () {
                 dispatcher.getStore('Invalid');
@@ -101,7 +101,7 @@ describe('Dispatchr', function () {
     describe('#dispatch', function () {
         it('should dispatch to store', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
 
             dispatcher.dispatch('NAVIGATE', {});
             expect(dispatcher.storeInstances).to.be.an('object');
@@ -117,7 +117,7 @@ describe('Dispatchr', function () {
 
         it('should allow stores to wait for other stores', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
 
             dispatcher.dispatch('DELAY', {});
             expect(dispatcher.getStore('Store').getState().page).to.equal('delay');
@@ -125,7 +125,7 @@ describe('Dispatchr', function () {
 
         it('should call stores that registered a default action', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
 
             dispatcher.dispatch('NAVIGATE', {});
             expect(dispatcher.getStore(delayedStore).defaultCalled).to.equal(true);
@@ -134,7 +134,7 @@ describe('Dispatchr', function () {
 
         it('should call stores that registered a default action that has no other handlers', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
 
             dispatcher.dispatch('FOO', {});
             expect(dispatcher.getStore(delayedStore).defaultCalled).to.equal(true);
@@ -143,7 +143,7 @@ describe('Dispatchr', function () {
 
         it('should not call the default handler if store has explicit action handler', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
             dispatcher.dispatch('DELAY', {});
             expect(dispatcher.getStore(delayedStore).defaultCalled).to.equal(false);
             expect(dispatcher.getStore(delayedStore).actionHandled).to.equal(null);
@@ -151,7 +151,7 @@ describe('Dispatchr', function () {
 
         it('should not swallow errors raised by store handler', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
             expect(function () {
                 dispatcher.dispatch('ERROR', {});
             }).to.throw();
@@ -161,7 +161,7 @@ describe('Dispatchr', function () {
 
         it('should throw if a dispatch called within dispatch', function () {
             var context = {test: 'test'},
-                dispatcher = new Dispatcher(context);
+                dispatcher = Dispatcher.create(context);
 
             expect(function () {
                 dispatcher.dispatch('DISPATCH', {
@@ -189,7 +189,7 @@ describe('Dispatchr', function () {
                     }
                 }
             };
-            dispatcher = new Dispatcher(context);
+            dispatcher = Dispatcher.create(context);
         });
 
         it('should dehydrate correctly', function () {
@@ -215,7 +215,7 @@ describe('Dispatchr', function () {
 
     describe('#shouldDehydrate', function () {
         it('should not dehydrate stores that return false from shouldDehydrate', function () {
-            var dispatcher = new Dispatcher();
+            var dispatcher = Dispatcher.create();
             dispatcher.dispatch('NAVIGATE', {});
             var state = dispatcher.dehydrate();
             expect(state.stores).to.be.an('object');

--- a/tests/unit/utils/BaseStore.js
+++ b/tests/unit/utils/BaseStore.js
@@ -15,13 +15,13 @@ var dispatcherMock = {
 
 describe('BaseStore', function () {
     it('instantiates correctly', function () {
-        var store = new BaseStore(dispatcherMock);
+        var store = BaseStore.create(dispatcherMock);
         expect(store.dispatcher).to.equal(dispatcherMock);
         expect(store.getContext()).to.equal(dispatcherMock.getContext());
     });
 
     it('allows listening for changes', function (done) {
-        var store = new BaseStore(dispatcherMock);
+        var store = BaseStore.create(dispatcherMock);
         var payloadMock = {
             foo: 'bar'
         };

--- a/tests/unit/utils/createStore.js
+++ b/tests/unit/utils/createStore.js
@@ -23,7 +23,7 @@ describe('createStore', function () {
                     expect(param).to.equal(mock.param);
                 }
             }),
-            store = new ExampleStore(mock.dispatcher);
+            store = ExampleStore.create(mock.dispatcher);
 
         store.test(mock.param);
         expect(ExampleStore.handlers).to.deep.equal(mock.handlers);
@@ -58,7 +58,7 @@ describe('createStore', function () {
                     expect(param).to.equal(mock.param);
                 }
             }),
-            store = new ExampleStore(mock.dispatcher);
+            store = ExampleStore.create(mock.dispatcher);
 
         store.test(mock.param);
         store.mixin_test(mock.param);

--- a/utils/BaseStore.js
+++ b/utils/BaseStore.js
@@ -4,32 +4,38 @@
  */
 'use strict';
 
-var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var CHANGE_EVENT = 'change';
+
 
 /**
  * @class BaseStore
  * @extends EventEmitter
+ */
+var BaseStore = Object.create(EventEmitter.prototype);
+
+/**
+ * Creates a new instance
  * @param dispatcher The dispatcher interface
  * @constructor
  */
-function BaseStore(dispatcher) {
-    this.dispatcher = dispatcher;
-    this._hasChanged = false;
-    if (this.initialize) {
-        this.initialize();
+BaseStore.create = function create(dispatcher) {
+    var obj = Object.create(this);
+    obj.dispatcher = dispatcher;
+    obj._hasChanged = false;
+    if (obj.initialize) {
+        obj.initialize();
     }
-}
 
-util.inherits(BaseStore, EventEmitter);
+    return obj;
+}
 
 /**
  * Convenience method for getting the store context object.
  * @method getContext
  * @return {Object} Returns the store context object.
  */
-BaseStore.prototype.getContext = function getContext() {
+BaseStore.getContext = function getContext() {
     return this.dispatcher.getContext();
 };
 
@@ -38,7 +44,7 @@ BaseStore.prototype.getContext = function getContext() {
  * @method addChangeListener
  * @param {Function} callback
  */
-BaseStore.prototype.addChangeListener = function addChangeListener(callback) {
+BaseStore.addChangeListener = function addChangeListener(callback) {
     this.on(CHANGE_EVENT, callback);
 };
 
@@ -47,7 +53,7 @@ BaseStore.prototype.addChangeListener = function addChangeListener(callback) {
  * @method removeChangeListener
  * @param {Function} callback
  */
-BaseStore.prototype.removeChangeListener = function removeChangeListener(callback) {
+BaseStore.removeChangeListener = function removeChangeListener(callback) {
     this.removeListener(CHANGE_EVENT, callback);
 };
 
@@ -58,7 +64,7 @@ BaseStore.prototype.removeChangeListener = function removeChangeListener(callbac
  * @method shouldDehydrate
  * @returns {boolean}
  */
-BaseStore.prototype.shouldDehydrate = function shouldDehydrate() {
+BaseStore.shouldDehydrate = function shouldDehydrate() {
     return this._hasChanged;
 };
 
@@ -67,7 +73,7 @@ BaseStore.prototype.shouldDehydrate = function shouldDehydrate() {
  * @method emitChange
  * @param {*} param=this
  */
-BaseStore.prototype.emitChange = function emitChange(param) {
+BaseStore.emitChange = function emitChange(param) {
     this._hasChanged = true;
     this.emit(CHANGE_EVENT, param || this);
 };

--- a/utils/createStore.js
+++ b/utils/createStore.js
@@ -4,8 +4,7 @@
  */
 'use strict';
 
-var util = require('util'),
-    BaseStore = require('./BaseStore'),
+var BaseStore = require('./BaseStore'),
     IGNORE_ON_PROTOTYPE = ['statics', 'storeName', 'handlers', 'mixins'];
 
 function createChainedFunction(one, two) {
@@ -50,12 +49,10 @@ module.exports = function createStore(spec) {
     if (!spec.storeName && !spec.statics.storeName) {
         throw new Error('createStore called without a storeName');
     }
-    var Store = function (dispatcher) {
-        BaseStore.call(this, dispatcher);
-    };
 
-    util.inherits(Store, BaseStore);
+    var Store = BaseStore.create();
 
+    // @deprecated: Statics should not be needed
     Object.keys(spec.statics).forEach(function (prop) {
         Store[prop] = spec.statics[prop];
     });
@@ -66,10 +63,10 @@ module.exports = function createStore(spec) {
 
     if (Store.mixins) {
         Store.mixins.forEach(function(mixin) {
-            mixInto(Store.prototype, mixin);
+            mixInto(Store, mixin);
         });
     }
-    mixInto(Store.prototype, spec);
+    mixInto(Store, spec);
 
     return Store;
 };


### PR DESCRIPTION
@mridgway this refactoring is the example of what i was proposing on https://github.com/yahoo/dispatchr/issues/53. The code should work the same, all tests pass, and there is some advantages in this approach:

* No memory waste with duplicated code, all shared code is in the prototype objects.
* Simpler design, no classes, objects inherit directly from each other, no `new` operator. 
* More flexible than pseudoclassical.
* 1 less dependency since there is no need for `require('util')`

