### PR TITLE
Throw an error when actionName param in Dispatcher#dispatch is falsy

### DIFF
--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -147,6 +147,10 @@ module.exports = function () {
      * @throws {Error} if store has handler registered that does not exist
      */
     Dispatcher.prototype.dispatch = function dispatch(actionName, payload) {
+        if (!actionName) {
+            throw new Error('actionName parameter `' + actionName + '` is invalid.');
+        }
+
         if (this.currentAction) {
             throw new Error('Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.');
         }

--- a/tests/unit/lib/Dispatcher.js
+++ b/tests/unit/lib/Dispatcher.js
@@ -167,6 +167,17 @@ describe('Dispatchr', function () {
             dispatcher.dispatch('DELAY', {});
         });
 
+        it('should throw if a dispatch called with falsy actionName parameter', function () {
+          var context = {test: 'test'},
+              dispatcher = new Dispatcher(context);
+
+            expect(function () {
+                dispatcher.dispatch(undefined, {
+                    dispatcher: dispatcher
+                });
+            }).to.throw();
+        });
+
         it('should throw if a dispatch called within dispatch', function () {
             var context = {test: 'test'},
                 dispatcher = new Dispatcher(context);


### PR DESCRIPTION
This should make it easier to catch typos when using constants as action names.