### PR TITLE
Fix require of eventemitter3

### DIFF
--- a/addons/BaseStore.js
+++ b/addons/BaseStore.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var inherits = require('inherits');
-var EventEmitter = require('eventemitter3').EventEmitter;
+var EventEmitter = require('eventemitter3');
 var CHANGE_EVENT = 'change';
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispatchr",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A Flux dispatcher for applications that run on the server and the client.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
`eventemitter3` module directly exports EventEmitter, not a named property as `events` had before a19a9e2dec6ef984f97ba882231a7e25a33016b6