### PR TITLE
Warn if store relies on store.name

### DIFF
--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -20,9 +20,11 @@ function Dispatcher (options) {
     this.stores = {};
     this.handlers = {};
     this.handlers[DEFAULT] = [];
+    this.hasWarnedAboutNameProperty = false;
     options.stores.forEach(function (store) {
         this.registerStore(store);
     }, this);
+
 }
 
 Dispatcher.prototype.createContext = function createContext(context) {
@@ -97,7 +99,22 @@ Dispatcher.prototype.getStoreName = function getStoreName(store) {
     if ('string' === typeof store) {
         return store;
     }
-    return store.storeName || store.name;
+    if (store.storeName) {
+        return store.storeName;
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+        if (store.name && !this.hasWarnedAboutNameProperty) {
+            console.warn('A store has been registered that relies on the ' +
+                'constructor\'s name property. This name may change when you ' +
+                'minify your stores during build time and could break string ' +
+                'references to your store. It is advised that you add a ' +
+                'static `storeName` property to your store to ensure the ' +
+                'store name does not change during your build.');
+            this.hasWarnedAboutNameProperty = true;
+        }
+    }
+    return store.name;
 };
 
 /**

--- a/tests/unit/lib/Dispatcher.js
+++ b/tests/unit/lib/Dispatcher.js
@@ -39,8 +39,10 @@ describe('Dispatchr', function () {
 
     describe('#registerStore', function () {
         it('should throw if store name is already registered', function () {
+            var NewStore = function Store () {};
+            NewStore.storeName = 'Store';
             expect(function () {
-                dispatcher.registerStore(function Store () {});
+                dispatcher.registerStore(NewStore);
             }).to.throw(Error);
         });
 
@@ -54,6 +56,17 @@ describe('Dispatchr', function () {
             expect(function () {
                 dispatcher.registerStore('store');
             }).to.throw(Error);
+        });
+
+        it('should warn if registering store that relies on name property', function () {
+            var oldWarn = console.warn;
+            var warning;
+            console.warn = function(message) {
+                warning = message;
+            };
+            dispatcher.registerStore(function NewStore() {});
+            console.warn = oldWarn;
+            expect(warning).to.not.equal(undefined);
         });
     });
 


### PR DESCRIPTION
Added warning message if store relies on `name` property which can change during minification.