### PR TITLE
Fixes #66 - Update dispatch doc block

### DIFF
--- a/lib/DispatcherContext.js
+++ b/lib/DispatcherContext.js
@@ -44,7 +44,7 @@ DispatcherContext.prototype.getStore = function getStore(name) {
 };
 
 /**
- * Dispatches a new action or queues it up if one is already in progress
+ * Dispatches a new action or throws if one is already in progress
  * @method dispatch
  * @param {String} actionName Name of the action to be dispatched
  * @param {Object} payload Parameters to describe the action


### PR DESCRIPTION
Fixes #66 - Doc block now states that additional dispatched actions throw if an action is executing rather than queue.